### PR TITLE
Added pip install kohya_ss requirements

### DIFF
--- a/kohya_ss_colab.ipynb
+++ b/kohya_ss_colab.ipynb
@@ -36,6 +36,7 @@
         "%cd /content\n",
         "!git clone -b v1.0 https://github.com/camenduru/kohya_ss\n",
         "%cd /content/kohya_ss\n",
+        "!pip install --upgrade -r requirements.txt\n",
         "\n",
         "!python kohya_gui.py --share --headless"
       ]


### PR DESCRIPTION
This line is required to use some of the utilities from the gui (for example some of the LoRA tools)